### PR TITLE
Add apt-mirror and security-apt-mirror configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,19 @@ juju deploy ./sshproxy.charm
 ### Configuring the charm:
 
 First of all, set the username and hostname of the VNF:
+
 ```bash
 juju config sshproxy ssh-hostname=<hostname> \
                      ssh-username=<username>
+```
+
+#### Mirrors
+
+To workaround this [bug](https://bugs.launchpad.net/juju/+bug/1929399), use the following configurations of the charm to specify the urls of apt and security mirrors.
+
+```bash
+juju config sshproxy apt-mirror=<apt-mirror> \
+                     security-apt-mirror=<security-apt-mirror>
 ```
 
 ### Credentials

--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,9 @@ options:
     type: int
     default: 4096
     description: "The number of bits to use for the SSH key."
+  apt-mirror:
+    type: string
+    description: "Apt mirror. Only used for K8s proxy charms with Juju version lower than 2.9.4"
+  security-apt-mirror:
+    type: string
+    description: "Security Apt mirror. Only used for K8s proxy charms with Juju version lower than 2.9.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ops
+packaging
 git+https://github.com/charmed-osm/charms.osm#egg=charms.osm


### PR DESCRIPTION
Related bug: https://bugs.launchpad.net/juju/+bug/1929399

For K8s Proxy charms with juju version lower than 2.9.4, we will configure the apt mirror and security mirrors if specified in the charm's config.

Related patch: https://github.com/charmed-osm/charms.osm/pull/13